### PR TITLE
MAC-Patch

### DIFF
--- a/FoodSnapFastApi/Dockerfile
+++ b/FoodSnapFastApi/Dockerfile
@@ -1,0 +1,38 @@
+# Use a lightweight official Python 3.10 image
+FROM python:3.10-slim
+
+# Set working directory inside the container
+WORKDIR /app
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    curl \
+    libglib2.0-0 \
+    libsm6 \
+    libxext6 \
+    libxrender-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Upgrade pip and setup tools
+
+
+RUN pip install --upgrade pip setuptools wheel
+
+# Copy requirements files
+COPY requirement.txt requirement.txt
+COPY requirement1.txt requirement1.txt
+
+# Install dependencies from both requirement files
+# Assumes you've updated torch/tensorflow versions in both files
+RUN pip install --no-cache-dir -r requirement.txt
+RUN pip install --no-cache-dir -r requirement1.txt
+
+# Copy all project files into the container
+COPY . .
+
+# Expose FastAPI port
+EXPOSE 8000
+
+# Start FastAPI using uvicorn
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]

--- a/FoodSnapFastApi/requirement.txt
+++ b/FoodSnapFastApi/requirement.txt
@@ -19,7 +19,7 @@ grpcio==1.49.0
 h11==0.13.0
 h5py==3.7.0
 idna==3.4
-keras==2.10.0
+keras==2.11.0
 Keras-Preprocessing==1.1.2
 kiwisolver==1.4.4
 libclang==14.0.6
@@ -44,11 +44,11 @@ rsa==4.9
 six==1.16.0
 sniffio==1.3.0
 starlette==0.20.4
-tensorboard==2.10.0
+tensorboard==2.11.0
 tensorboard-data-server==0.6.1
 tensorboard-plugin-wit==1.8.1
-tensorflow==2.4.1
-tensorflow-estimator==2.10.0
+tensorflow==2.11.0
+tensorflow-estimator==2.11.0
 tensorflow-io-gcs-filesystem==0.27.0
 termcolor==2.0.1
 typing_extensions==4.3.0
@@ -56,3 +56,6 @@ urllib3==1.26.12
 uvicorn==0.18.3
 Werkzeug==2.2.2
 wrapt==1.14.1
+altair==4.2.2
+attrs==23.1.0
+jsonschema==4.17.3

--- a/FoodSnapFastApi/requirement1.txt
+++ b/FoodSnapFastApi/requirement1.txt
@@ -10,7 +10,7 @@ idna==3.3
 iniconfig==1.1.1
 Jinja2==3.0.2
 MarkupSafe==2.0.1
-numpy==1.21.3
+numpy==1.23.3
 packaging==21.0
 Pillow==8.4.0
 pluggy==1.0.0
@@ -25,8 +25,8 @@ sniffio==1.2.0
 starlette==0.16.0
 toml==0.10.2
 -f https://download.pytorch.org/whl/torch_stable.html
-torch==1.8.1+cpu
-torchvision==0.9.1+cpu
+torch==2.1.0
+torchvision==0.16.0
 typing-extensions==3.10.0.2
 urllib3==1.26.7
 uvicorn==0.15.0


### PR DESCRIPTION
Existing version of tensorflow didn't work on mac and build failed; 
fix: reversioning and containerization is done
supported: all platform